### PR TITLE
Configure linux-renesas to build uinput

### DIFF
--- a/meta-rcar-gen2/recipes-kernel/linux/linux.inc
+++ b/meta-rcar-gen2/recipes-kernel/linux/linux.inc
@@ -118,6 +118,9 @@ do_configure_prepend() {
         kernel_configure_variable QUOTA y
         kernel_configure_variable BT y
 
+        # add uinput for automated testing
+        kernel_configure_variable INPUT_MISC y
+        kernel_configure_variable INPUT_UINPUT y
 
 	# Keep this the last line
 	# Remove all modified configs and add the rest to .config


### PR DESCRIPTION
Hi Stephen,

I'd like to add a change to the meta-renesas recipes to add uinput to the kernel. If this patch is unacceptable, I can investigate building uinput as a kernel module if that would be preferred.

Commit message as follows:

The uinput module is useful for automated testing as it allows
user-space programmes to create and use virtual input devices.

An alternative way of doing this might be to add configuration using the
way recommended by
http://www.yoctoproject.org/docs/1.7.2/kernel-dev/kernel-dev.html#changing-the-configuration,
but I was unable to get that working.

Signed-off-by: Jonathan Maw jonathan.maw@codethink.co.uk
