### PR TITLE
rcar-gen2: Add gudev dependency to gst-plugins-good

### DIFF
--- a/meta-rcar-gen2/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.2.3.bbappend
+++ b/meta-rcar-gen2/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.2.3.bbappend
@@ -7,6 +7,8 @@ LIC_FILES_CHKSUM_remove_rcar-gen2 = "\
 
 S = "${WORKDIR}/git"
 
+DEPENDS += " libgudev "
+
 do_configure_prepend() {
     cd ${S}
     ./autogen.sh --noconfigure


### PR DESCRIPTION
Without this set, GDP builds fail:

https://at.projects.genivi.org/jira/browse/GDP-561